### PR TITLE
Add monitoring of free diskspace and pins total size

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,20 @@
+## Monitoring
+
+Just another component.
+
+### What we want to monitor?
+
+- Disk + Memory + CPU + Bandwidth of Instance
+- Sizes of Pins (actually saved, and in general when all pins are done)
+- Cluster Health (nodes connected? Link health?)
+
+### What else we want?
+- Exposing Prometheus endpoint
+- Compose go-ipfs + ipfs-cluster prometheus metrics
+- Host metrics
+
+## Other thoughts
+- Embed Grafana?
+- Storage in memory for now. In the future, need to buffered to disk
+- Not together with the rest of application state, only chosen, last values
+  go there, to avoid sending too much data to frontend

--- a/project.clj
+++ b/project.clj
@@ -38,9 +38,7 @@
                  [clj-ssh "0.5.14"]
                  [ring-json-response "0.2.0"]
                  [aleph "0.4.6"]
-                 ;; TODO waiting for new version
-                 ;; [lispyclouds/clj-docker-client "0.1.12-SNAPSHOT"]
-                 [victorb/clj-docker-client "0.1.12-SNAPSHOT"]
+                 [lispyclouds/clj-docker-client "0.1.12"]
                  [com.fasterxml.jackson.core/jackson-core "2.9.8"]
                  [org.clojure/tools.trace "0.7.10"]
                  [org.clojure/clojurescript "1.10.238"]
@@ -53,7 +51,8 @@
                  [org.clojure/test.check "0.10.0-alpha3"]
                  [figwheel-sidecar "0.5.18"]
                  [cider/piggieback "0.3.10"]
-                 [binaryage/devtools "0.9.10"]]
+                 [binaryage/devtools "0.9.10"]
+                 [clojure-humanize "0.2.2"]]
   ;; TODO make run for `uberjar` but not the rest
   ;; :prep-tasks ["compile" ["do" ["shell" "make" "install"]
   ;;                              ["cljsbuild" "once"]

--- a/src/cube/cluster.clj
+++ b/src/cube/cluster.clj
@@ -20,29 +20,51 @@
 (defn get-api-addr [instances]
   (:cluster-api (second (first (instances/get-running instances)))))
 
+(defn get-proxy-addr [instances]
+  (:ipfs-proxy (second (first (instances/get-running instances)))))
+
 (defn get-name-for-pin [api-addr pin]
   (-> (http/get (format "%s/allocations/%s" api-addr (:cid pin)) {:as :json})
       :body
       :name))
 
-(defn set-name-for-pin [api-addr pin]
+(defn get-size-for-pin [proxy-addr pin]
+  (-> (http/get (format "%s/api/v0/object/stat/%s" proxy-addr (:cid pin)) {:as :json})
+      :body
+      :CumulativeSize))
+
+(defn set-name [api-addr pin]
   (if (nil? (:name pin))
     (assoc pin :name (get-name-for-pin api-addr pin))
     pin))
 
-(defn set-names-for-pins [api-addr pins]
-  (map #(set-name-for-pin api-addr %) pins))
+(defn set-size [proxy-addr pin]
+  (if (nil? (:size pin))
+    (assoc pin :size (get-size-for-pin proxy-addr pin))))
+
+(defn set-for-pins [func addr pins]
+  (map #(func addr %) pins))
 
 (defn update-pins [db instances]
-  (let [api-addr (:cluster-api (second (first (instances/get-running instances))))]
+  (let [inst (second (first (instances/get-running instances)))
+        api-addr (:cluster-api inst)
+        proxy-addr (:ipfs-proxy inst)]
     (when api-addr
       (let [pins (format-res (:body (http/get (format "%s/pins" api-addr) {:as :json})))]
-        (db/put db :pins (set-names-for-pins api-addr pins))))))
+        (->> pins
+            (set-for-pins set-name api-addr)
+            (set-for-pins set-size proxy-addr)
+            (db/put db :pins))))))
 
 (defn add-new-pin [instances cid cid-name]
   (http/post
     (format "%s/pins/%s?name=%s" (get-api-addr instances) cid cid-name)
     {:as :json}))
+
+(defn get-freespace-metrics [cluster]
+  (:body (http/get
+           (format "%s/monitor/metrics/freespace" (get-api-addr (:instances cluster)))
+           {:as :json})))
 
 (defrecord Cluster [db scheduler instances]
   c/Lifecycle
@@ -66,3 +88,6 @@
   (http/delete
     (format "%s/pins/%s" (get-api-addr (:instances cluster)) cid)
     {:as :json}))
+
+(defn get-pins [cluster]
+  (db/access (:db cluster) :pins))

--- a/src/cube/monitoring.clj
+++ b/src/cube/monitoring.clj
@@ -1,0 +1,114 @@
+(ns cube.monitoring
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]
+            [com.stuartsierra.component :as c]
+            [cube.cluster :as cluster]
+            [cube.instances :as instances]
+            [cube.db :as db]
+            [cube.scheduler :as scheduler]))
+
+(s/def ::timestamp string?)
+
+(s/def ::value int?)
+
+(s/def ::entry (s/keys :req-un [::timestamp
+                                ::value]))
+
+(s/def ::history (s/coll-of ::entry))
+
+(s/def ::current ::entry)
+
+(s/def ::pinsize (s/keys :req-un [::current
+                                  ::history]))
+
+(s/def ::freespace (s/keys :req-un [::current
+                                    ::history]))
+
+(s/def ::state (s/keys :req-un [::pinsize
+                                ::freespace]))
+
+(def state (atom {:freespace {:current nil :history []}
+                  :pinsize {:current nil :history []}}))
+
+
+(s/fdef get-current-time
+        :ret int?)
+
+(defn get-current-time [] (quot (System/currentTimeMillis) 1000))
+
+(s/fdef add-to-state
+        :args (s/cat :entry ::entry)
+        :ret nil?)
+
+(defn add-to-state! [entry t]
+  (do
+    (swap! state assoc-in [t :current] entry)
+    (swap! state update-in [t :history] conj entry)))
+
+(s/fdef calculate-total-pin-size
+        :args (s/cat :pins :cube/pins)
+        :ret (s/and int? pos?))
+
+(defn calculate-total-pin-size [pins]
+  (reduce (fn [acc curr] (+ acc (:size curr))) 0 pins))
+
+(s/def :freespace/name string?)
+(s/def :freespace/peer string?)
+(s/def :freespace/value string?)
+(s/def ::freespace-from-cluster (s/keys :req-un [:freespace/name
+                                                 :freespace/peer
+                                                 :freespace/value]))
+
+(s/fdef calculate-total-freespace
+        :args (s/cat :freespaces ::freespace-from-cluster)
+        :ret (s/and int?))
+
+(defn calculate-total-freespace [freespaces]
+  (reduce (fn [acc curr] (+ acc (Long/parseLong (:value curr)))) 0 freespaces))
+
+(s/fdef create-entry
+        :args (s/cat :value ::value)
+        :ret ::entry)
+
+(defn create-entry [size]
+  {:value size
+   :timestamp (get-current-time)})
+
+(defn check-pin-total-size [cluster]
+  (-> cluster
+      (cluster/get-pins)
+      (calculate-total-pin-size)
+      (create-entry)
+      (add-to-state! :pinsize)))
+
+(defn check-cluster-freespace [cluster]
+  (-> cluster
+      (cluster/get-freespace-metrics)
+      (calculate-total-freespace)
+      (create-entry)
+      (add-to-state! :freespace)))
+
+(defn check-metrics [instances cluster]
+  (when (> (count (instances/get-running instances)) 0)
+    (do (check-pin-total-size cluster)
+        (check-cluster-freespace cluster))))
+
+(defn set-db-current-value [db]
+  (db/put-in db [:monitoring :pinsize] (-> @state :pinsize :current))
+  (db/put-in db [:monitoring :freespace] (-> @state :freespace :current)))
+
+(defrecord Monitoring [db scheduler instances cluster]
+  c/Lifecycle
+  (start [this]
+    (println "[monitoring] Starting")
+    (scheduler/add-task scheduler #(check-metrics instances cluster))
+    (scheduler/add-task scheduler #(set-db-current-value db))
+    (-> (create-entry 0) (add-to-state! :freespace))
+    (-> (create-entry 0) (add-to-state! :pinsize))
+    this)
+  (stop [this]
+    (println "[monitoring] Stopping")
+    this))
+
+(defn new []
+  (map->Monitoring {}))

--- a/src/cube/system.clj
+++ b/src/cube/system.clj
@@ -6,7 +6,8 @@
             [cube.setup :as setup]
             [cube.instances :as instances]
             [cube.providers.docker :as provider-docker]
-            [cube.cluster :as cluster]))
+            [cube.cluster :as cluster]
+            [cube.monitoring :as monitoring]))
 
 (defn create-system [config-options]
   (let [{http-port :http-port
@@ -18,4 +19,5 @@
                   :instances (c/using (instances/new) [:db :scheduler :docker])
                   :docker (provider-docker/new "unix:///var/run/docker.sock")
                   :cluster (c/using (cluster/new) [:db :scheduler :instances])
+                  :monitoring (c/using (monitoring/new) [:db :scheduler :instances :cluster])
                   )))

--- a/src/cube/web.clj
+++ b/src/cube/web.clj
@@ -9,6 +9,7 @@
             [clojure.pprint :refer [pprint]]
             [cube.db :as db]
             [cube.setup :as setup]
+            [cube.monitoring :as monitoring]
             [cube.instances :as instances]
             [cube.cluster :as cluster]
             [ring.middleware.reload :refer [wrap-reload]]
@@ -88,7 +89,8 @@
                                              instances
                                              (keyword instance-type)
                                              instance-count)
-                                           {:status 200})))
+                                           {:status 200}))
+                         (compojure/GET "/monitoring" [] (json/write-str @cube.monitoring/state)))
       ;; TODO leading to issues in uberjar with `Stream Closed` and what-not
       ;; (route/not-found (resource-response "index.html" {:root "public"}))
       (compojure/GET "/*" []

--- a/src/shared/db.cljc
+++ b/src/shared/db.cljc
@@ -93,8 +93,11 @@
 
 (s/def :cube.pin/name :cube.util/not-empty-string)
 
+(s/def :cube.pin/size (s/and int? pos?))
+
 (s/def :cube.pins/pin (s/keys :req-un [:cube.pin/cid
                                        :cube.pin/name
+                                       :cube.pin/size
                                        :cube.pin/peer-map]))
 
 (s/def :cube/pins (s/coll-of :cube.pins/pin))

--- a/src/ui/monitoring.cljs
+++ b/src/ui/monitoring.cljs
@@ -1,0 +1,20 @@
+(ns ui.monitoring
+  (:require [re-frame.core :refer [reg-sub]]
+            [day8.re-frame.tracing :refer-macros [fn-traced]]))
+
+(reg-sub
+  :monitoring
+  (fn-traced [db _]
+             (-> db :remote-db :monitoring)))
+
+(reg-sub
+  :monitoring/pinsize
+  :<- [:monitoring]
+  (fn-traced [monitoring]
+             (:pinsize monitoring)))
+
+(reg-sub
+  :monitoring/freespace
+  :<- [:monitoring]
+  (fn-traced [monitoring]
+             (:freespace monitoring)))

--- a/src/ui/navigation.cljs
+++ b/src/ui/navigation.cljs
@@ -2,15 +2,15 @@
   (:require [re-frame.core :refer [subscribe]]
             [ui.router :as router]))
 
-(def navbar-items {"/home" "Home"
-                   "/upload" "Upload"
-                   "/pins" "Pins"
-                   "/instances" "Instances"
-                   "/users" "Users"
-                   "/groups" "Groups"
-                   "/preferences" "Preferences"})
-
-(def disabled-items ["/upload" "/users" "/groups" "/preferences"])
+(def navbar-items [{:url "/home" :title "Home" :active true}
+                   {:url "/upload" :title "Upload" :active false}
+                   {:url "/pins" :title "Pins" :active true}
+                   {:url "/instances" :title "Instances" :active true}
+                   {:url "/users" :title "Users" :active false}
+                   {:url "/groups" :title "Groups" :active false}
+                   {:url "/monitoring" :title "Monitoring" :active true}
+                   {:url "/preferences" :title "Preferences" :active false}
+                   {:url "/logout" :title "Logout" :active false}])
 
 (defn href-attr [url enabled?]
   {:href (if enabled? url "")
@@ -36,8 +36,9 @@
      [:a.link.dim.white.b.f3.dib.mr3.aqua (href-attr "/home" setup-completed?) "Cube"]
      (let [active-page @(subscribe [:active-page])]
        (for [item navbar-items]
-         (let [[url title] item]
-           (let [matched? (= active-page url)
-                 is-enabled? (not (includes? disabled-items url))]
-             (create-navbar-item url title matched? is-enabled?)))))]))
+         (let [url (:url item)
+               title (:title item)
+               active (:active item)
+               matched? (= active-page url)]
+           (create-navbar-item url title matched? active))))]))
 

--- a/src/ui/pages/monitoring.cljs
+++ b/src/ui/pages/monitoring.cljs
@@ -1,0 +1,45 @@
+(ns ui.pages.monitoring
+  (:require [re-frame.core :refer [subscribe dispatch]]
+            [ui.monitoring :as monitoring]
+            [clojure.contrib.humanize :refer [filesize]]))
+
+(defn unix->jsdate [unix-timestamp]
+  (js/Date. (* unix-timestamp 1000)))
+
+(def colors {:ok "bg-aqua"
+             :warn "bg-yellow"
+             :danger "bg-red"})
+
+(defn diskspace-colors [current-val]
+  (cond
+    (= current-val 0) (:danger colors)
+    ;; Less than 10GB
+    (< current-val 10000000000) (:warn colors)
+    ;; More than 10GB
+    (> current-val 10000000000) (:ok colors)
+    :else "bg-gray"))
+
+(defn render []
+  (let [pinsize @(subscribe [:monitoring/pinsize])
+        freespace @(subscribe [:monitoring/freespace])]
+    [:div
+     [:div.ma1.pa1 (str "Last Update: " (-> pinsize :timestamp unix->jsdate))]
+     [:div.tc.w-20.bg-aqua.white.pa2.ma1.fl
+      [:div.f3.b "Spaced used by Pins"]
+      [:div.monospace.mt2.f4 (-> pinsize :value filesize)]]
+     [:div.tc.w-20.white.pa2.ma1.fl {:class (diskspace-colors (-> freespace :value))}
+      [:div.f3.b "Free Diskspace"]
+      [:div.monospace.mt2.f4 (-> freespace :value filesize)]]
+     [:div.tc.w-20.bg-aqua.white.pa2.ma1.fl
+      [:div.f3.b "CPU"]
+      [:div.monospace.mt2.f4 "25%"]]
+     [:div.tc.w-20.bg-red.white.pa2.ma1.fl
+      [:div.f3.b "Memory"]
+      [:div.monospace.mt2.f4 "64%"]]
+     [:div.tc.w-20.bg-aqua.white.pa2.ma1.fl
+      [:div.f3.b "Network"]
+      [:div.monospace.mt2.f5 "24Mbps / 12Mbps (▲/▼)"]]
+     [:div.cf]
+     [:div.mt3 "Notice: Currently this only actually updates the 'Spaced used by
+               Pins' and 'Free Diskspace' values. Other values are mock values
+               and not real."]]))

--- a/src/ui/pages/pin.cljs
+++ b/src/ui/pages/pin.cljs
@@ -1,5 +1,6 @@
 (ns ui.pages.pin
-  (:require [re-frame.core :refer [subscribe dispatch]]))
+  (:require [re-frame.core :refer [subscribe dispatch]]
+            [clojure.contrib.humanize :refer [filesize]]))
 
 (defn peer-map [p]
   [:div.mt3
@@ -32,6 +33,9 @@
      [:div.f6.mt1
       [:span.b.monospace "Pinners: "]
       [:span (-> pin :peer-map count)]]
+     [:div.f6.mt1
+      [:span.b.monospace "Size: "]
+      [:span (filesize (:size pin))]]
      [:div.f3.mt4.b "Peers"]
      (for [p (:peer-map pin)]
        (peer-map p))]))

--- a/src/ui/pages/pins.cljs
+++ b/src/ui/pages/pins.cljs
@@ -4,6 +4,7 @@
             [ui.components.button :as button]
             [ui.components.text-input :as text-input]
             [ui.pins :as pins]
+            [clojure.contrib.humanize :refer [filesize]]
             ))
 
 (defn no-instances-message []
@@ -80,6 +81,7 @@
       [:tr.stripe-dark
        [:th.fw6.tl.pa3.bg-white "Hash"]
        [:th.fw6.tl.pa3.bg-white "Name"]
+       [:th.fw6.tl.pa3.bg-white "Size"]
        [:th.fw6.tl.pa3.bg-white "Pinning"]
        [:th.fw6.tl.pa3.bg-white "Pinned"]
        [:th.fw6.tl.pa3.bg-white "Error"]
@@ -93,9 +95,11 @@
         [:tr.stripe-dark {:key (:cid pin)}
          [:td.pa3 (:cid pin)]
          [:td.pa3 (:name pin)]
+         [:td.pa3 (filesize (:size pin))]
          [:td.pa3 (count-pinning pin)]
          [:td.pa3 (count-pinned pin)]
-         [:td.pa3 (count-errors pin)]
+         (let [err (count-errors pin)]
+           [:td.pa3 {:class (when (> err 0) "red")} err])
          [:td.pa3 (details-link (:cid pin))]
          [:td.pa3 [:a.f5.aqua "View in webui"]]
          [:td.pa3 [:a.f5.aqua {:href (get-ipfs-io-link pin)} "View on ipfs.io"]]

--- a/src/ui/router.cljs
+++ b/src/ui/router.cljs
@@ -13,6 +13,7 @@
             [ui.pages.instances :as instances]
             [ui.pages.users :as users]
             [ui.pages.groups :as groups]
+            [ui.pages.monitoring :as monitoring]
             [ui.pages.preferences :as preferences]
             [ui.pages.setup :as setup-page]
             [ui.pages.setup.welcome :as setup-welcome]
@@ -48,6 +49,7 @@
                  "instances" instances/render
                  "users" users/render
                  "groups" groups/render
+                 "monitoring" monitoring/render
                  "preferences" preferences/render
                  "setup" setup-page/render
                  ["setup/" :password "/welcome"] setup-welcome/render

--- a/src/ui/state.cljs
+++ b/src/ui/state.cljs
@@ -1,8 +1,7 @@
 (ns ui.state (:require
             [re-frame.core :refer [reg-event-db reg-sub]]
             ;; TODO ruins dead code elimation
-            [day8.re-frame.tracing :refer-macros [fn-traced]]
-               ))
+            [day8.re-frame.tracing :refer-macros [fn-traced]]))
 
 ;; contains:
 ;; - map of the initial state


### PR DESCRIPTION
Getting the size from object.stat of the pins, and adding them together.

Free diskspace comes directly from ipfs-cluster nodes.

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>