### PR TITLE
add cluster status fn

### DIFF
--- a/src/cube/cluster.clj
+++ b/src/cube/cluster.clj
@@ -91,3 +91,15 @@
 
 (defn get-pins [cluster]
   (db/access (:db cluster) :pins))
+
+(defn status [cluster cid]
+  (:body
+    (http/get
+      (format "%s/pins/%s" (get-api-addr (:instances cluster)) cid)
+      {:as :json})))
+
+(defn status-all [cluster]
+  (:body
+    (http/get
+      (format "%s/pins" (get-api-addr (:instances cluster)))
+      {:as :json})))

--- a/src/cube/providers/docker.clj
+++ b/src/cube/providers/docker.clj
@@ -9,7 +9,7 @@
 
 ;; Which images to use for the containers
 (def images {:go-ipfs "ipfs/go-ipfs:v0.4.18"
-             :ipfs-cluster "ipfs/ipfs-cluster:v0.7.0"})
+             :ipfs-cluster "ipfs/ipfs-cluster:v0.8.0"})
 
 ;; Keyword for this particular provider
 (def provider-type :docker)


### PR DESCRIPTION
Add `status` and `status-all` which get the status of either a cid or all pins from cluster directly.

Also, bump cluster container version.